### PR TITLE
Enhance data fetching via CSV sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Quant AI Trader
 
-This project fetches cryptocurrency market data from CoinGecko and generates
-basic trading signals. If the API is unreachable, deterministic synthetic data
-is used so the app continues to run without network access.
+This project fetches cryptocurrency market data from CoinGecko and now also
+supports pulling prices from CSV files hosted on GitHub. If online APIs are
+unreachable you can point the app at your own historical datasets so it never
+needs to rely on synthetic prices.
 
 ## Setup
 
@@ -51,4 +52,18 @@ unreachable, ensuring all features continue to work.
 The new `ElizaOS` component orchestrates these modules to provide a single
 entry point for rich analytics and trade ideas, making the application act as a
 comprehensive AI trading assistant.
+
+### Using Custom Data Sources
+
+Add CSV URLs under the `data_urls` section of `config/config.yaml` to load
+historical prices from GitHub (or any direct link). Example:
+
+```yaml
+data_urls:
+  BTC:
+    raw: https://raw.githubusercontent.com/Zombie-3000/Bitfinex-historical-data/master/BTCUSD/Candles_1m/2013/merged.csv
+```
+
+ElizaOS will resample these files to the requested timeframe and use them before
+falling back to APIs or synthetic data.
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,3 +8,6 @@ assets:
   - SOL
   - SUI
   - SEI
+data_urls:
+  BTC:
+    raw: https://raw.githubusercontent.com/Zombie-3000/Bitfinex-historical-data/master/BTCUSD/Candles_1m/2013/merged.csv


### PR DESCRIPTION
## Summary
- add ability to specify CSV price data URLs
- use CSV data for price, market-cap and week change if available
- document `data_urls` feature in README
- include example data URL in config

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m src.main` *(fails to fetch from CoinGecko due to network block but succeeds with CSV data)*

------
https://chatgpt.com/codex/tasks/task_e_686af4f715608331ac9be8c774d8c78a